### PR TITLE
quick fix to concatenate timestamps

### DIFF
--- a/mease_lab_to_nwb/convert_syntalos/syntalosimageinterface.py
+++ b/mease_lab_to_nwb/convert_syntalos/syntalosimageinterface.py
@@ -46,6 +46,6 @@ class SyntalosImageInterface(BaseDataInterface):
             description="Videos recorded by TIS camera.",
             format="external",
             external_file=video_file_path_list,
-            timestamps=H5DataIO(video_timestamps[0], compression="gzip")
+            timestamps=H5DataIO(np.concatenate(video_timestamps), compression="gzip")
         )
         nwbfile.add_acquisition(videos)


### PR DESCRIPTION
@bendichter When multiple `.mkv` files are present, this concatenates their timestamps.

I've submitted an [issue upstream](https://github.com/NeurodataWithoutBorders/pynwb/issues/1318) to see if this is the correct approach (I doubt it is), and if not if they can allow timestamps to be a list of the same length as the passed `.mkv` locations.