### PR TITLE
Extended SyntalosRecordingExtractor to deal with multiple rhd files

### DIFF
--- a/mease_lab_to_nwb/convert_syntalos/syntalosrecordingextractor.py
+++ b/mease_lab_to_nwb/convert_syntalos/syntalosrecordingextractor.py
@@ -7,7 +7,7 @@ from edlio.dataio.tsyncfile import TSyncFile, LegacyTSyncFile
 
 def SyntalosRecordingExtractor(folder_path):
     """
-    Function that routs the right parameters to a SyntalosSingleRecordingExtractor or a SyntalosMultiRecordingExtractor
+    Function that routes the right parameters to a SyntalosSingleRecordingExtractor or a SyntalosMultiRecordingExtractor
 
     Parameters
     ----------


### PR DESCRIPTION
The Syntalos system has the option to save multiple rhd file (e.g. every 3 minutes).

This PR extends the `SyntalosRecordingExtractor` to:
- a `SyntalosSingleRecordingExtractor` (deals with single .rhd and inherits directly from `IntanRecordingExtractor`) 
- a  `SyntalosMultiRecordingExtractor` (deals with multiple rhd files, takes care of sorting date times, and inherits from `MultiRecordingTimeExtractor`)

In order to make it easy to use, the `SyntalosRecordingExtractor` is now a function that returns an instance of the `SyntalosSingleRecordingExtractor` when a single rhd file is present, or a `SyntalosMultiRecordingExtractor` when there are multiple rhd files.

The tsync synchronization has been checked against edlio in both cases and it gives the same results, but faster :)
Tested on the new `Sliced_Recording` Syntalos dataset.