### PR TITLE
updating CED script to nwb-conversion-tools v0.6.2

### DIFF
--- a/mease_lab_to_nwb/convert_ced/cednwbconverter.py
+++ b/mease_lab_to_nwb/convert_ced/cednwbconverter.py
@@ -6,3 +6,12 @@ class CEDNWBConverter(NWBConverter):
     data_interface_classes = dict(
         CEDRecording=CEDRecordingInterface,
     )
+
+    def get_metadata(self):
+        """Auto-populate as much metadata as possible."""
+        metadata = super().get_metadata()
+        metadata['NWBFile'].update(
+            institution="EMBL - Heidelberg",
+            lab="Mease"
+        )
+        return metadata

--- a/mease_lab_to_nwb/convert_ced/convert_ced.py
+++ b/mease_lab_to_nwb/convert_ced/convert_ced.py
@@ -1,31 +1,35 @@
 """Authors: Cody Baker and Ben Dichter."""
 from pathlib import Path
+from spikeextractors import CEDRecordingExtractor
 
-from .cednwbconverter import CEDNWBConverter
+from cednwbconverter import CEDNWBConverter
 
-n_jobs = 1  # number of parallel streams to run
 
-base_path = Path("D:/CED_example_data")
-ced_file_path = base_path / "m365_pt1_590-1190secs-001.smrx"
+base_path = Path("D:/CED_example_data/Short example")
+ced_file_path = base_path / "M113_C4.smrx"
 nwbfile_path = base_path / "CED_stub.nwb"
 
-# Manual list of selected sessions that cause problems with the general functionality
-exlude_sessions = []
-nwbfile_paths = []
+channel_info = CEDRecordingExtractor.get_all_channels_info(ced_file_path)
 
+rhd_channels = []
+for ch, info in channel_info.items():
+    if "Rhd" in info["title"]:
+        rhd_channels.append(ch)
 
-if base_path.is_dir():
-    source_data = dict(
-        CEDRecording=dict(file_path=str(ced_file_path.absolute()), dtype="uint16")
+source_data = dict(
+    CEDRecording=dict(
+        file_path=str(ced_file_path.absolute()),
+        smrx_ch_inds=rhd_channels
     )
-    conversion_options = dict(
-        CEDRecording=dict(stub_test=True)
-    )
+)
+conversion_options = dict(
+    CEDRecording=dict(stub_test=True)
+)
 
-    converter = CEDNWBConverter(source_data)
-    metadata = converter.get_metadata()
-    converter.run_conversion(
-        nwbfile_path=str(nwbfile_path.absolute()),
-        metadata=metadata,
-        conversion_options=conversion_options
-    )
+converter = CEDNWBConverter(source_data)
+metadata = converter.get_metadata()
+converter.run_conversion(
+    nwbfile_path=str(nwbfile_path.absolute()),
+    metadata=metadata,
+    conversion_options=conversion_options
+)

--- a/mease_lab_to_nwb/convert_ced/convert_ced.py
+++ b/mease_lab_to_nwb/convert_ced/convert_ced.py
@@ -1,28 +1,31 @@
 """Authors: Cody Baker and Ben Dichter."""
-# TODO: add pathlib
-import os
-
-from joblib import Parallel, delayed
+from pathlib import Path
 
 from .cednwbconverter import CEDNWBConverter
 
 n_jobs = 1  # number of parallel streams to run
 
-base_path = "D:/Heidelberg_data/CED_example_data"
+base_path = Path("D:/CED_example_data")
+ced_file_path = base_path / "m365_pt1_590-1190secs-001.smrx"
+nwbfile_path = base_path / "CED_stub.nwb"
 
 # Manual list of selected sessions that cause problems with the general functionality
 exlude_sessions = []
 nwbfile_paths = []
 
 
-def run_ced_conv(virmen_session, spikeglx_session, nwbfile_path):
-    """Conversion function to be run in parallel."""
-    if os.path.exists(base_path):
-        print(f"Processsing {virmen_session}...")
-        if not os.path.isfile(nwbfile_path):
-            converter = CEDNWBConverter(**input_args)
-            metadata = converter.get_metadata()
+if base_path.is_dir():
+    source_data = dict(
+        CEDRecording=dict(file_path=str(ced_file_path.absolute()), dtype="uint16")
+    )
+    conversion_options = dict(
+        CEDRecording=dict(stub_test=True)
+    )
 
-            converter.run_conversion(nwbfile_path=nwbfile_path, metadata_dict=metadata, stub_test=True)
-    else:
-        print(f"The folder ({base_path}) does not exist!")
+    converter = CEDNWBConverter(source_data)
+    metadata = converter.get_metadata()
+    converter.run_conversion(
+        nwbfile_path=str(nwbfile_path.absolute()),
+        metadata=metadata,
+        conversion_options=conversion_options
+    )

--- a/mease_lab_to_nwb/convert_ced/convert_ced.py
+++ b/mease_lab_to_nwb/convert_ced/convert_ced.py
@@ -7,7 +7,12 @@ from cednwbconverter import CEDNWBConverter
 
 base_path = Path("D:/CED_example_data/Short example")
 ced_file_path = base_path / "M113_C4.smrx"
+# base_path = Path("D:/CED_example_data/Other example")
+# ced_file_path = base_path / "m365_pt1_590-1190secs-001.smrx"
 nwbfile_path = base_path / "CED_stub.nwb"
+
+from datetime import datetime
+session_start_time = datetime(2000,1,1)
 
 channel_info = CEDRecordingExtractor.get_all_channels_info(ced_file_path)
 
@@ -28,6 +33,7 @@ conversion_options = dict(
 
 converter = CEDNWBConverter(source_data)
 metadata = converter.get_metadata()
+metadata['NWBFile'].update(session_start_time=session_start_time)
 converter.run_conversion(
     nwbfile_path=str(nwbfile_path.absolute()),
     metadata=metadata,

--- a/mease_lab_to_nwb/convert_ced/convert_ced.py
+++ b/mease_lab_to_nwb/convert_ced/convert_ced.py
@@ -5,14 +5,9 @@ from spikeextractors import CEDRecordingExtractor
 from cednwbconverter import CEDNWBConverter
 
 
-base_path = Path("D:/CED_example_data/Short example")
-ced_file_path = base_path / "M113_C4.smrx"
-# base_path = Path("D:/CED_example_data/Other example")
-# ced_file_path = base_path / "m365_pt1_590-1190secs-001.smrx"
+base_path = Path("D:/CED_example_data/Other example")
+ced_file_path = base_path / "m365_pt1_590-1190secs-001.smrx"
 nwbfile_path = base_path / "CED_stub.nwb"
-
-from datetime import datetime
-session_start_time = datetime(2000,1,1)
 
 channel_info = CEDRecordingExtractor.get_all_channels_info(ced_file_path)
 
@@ -33,7 +28,6 @@ conversion_options = dict(
 
 converter = CEDNWBConverter(source_data)
 metadata = converter.get_metadata()
-metadata['NWBFile'].update(session_start_time=session_start_time)
 converter.run_conversion(
     nwbfile_path=str(nwbfile_path.absolute()),
     metadata=metadata,


### PR DESCRIPTION
@bendichter This will solve [Issue 15](https://github.com/catalystneuro/mease-lab-to-nwb/issues/15) once it's working.

@alejoe91 @luiztauffer When running this on `CED_example_data/Short example/M113_C4.smrx`, I get the error posted below

![image](https://user-images.githubusercontent.com/51133164/101288468-d022ee80-37c4-11eb-8792-e308a787811e.png)

Any ideas what's going wrong?

Also, I'm not crazy about how the user has to manually extract and specify the `rhd` channels to initialize the extractor, is there a 
reason why is this not handled internally like in other extractors? I remember something about the channel names not being "native" and therefore not being trustable or something?