### PR TITLE
separating notebook improvements to different PR

### DIFF
--- a/notebooks/syntalos_spikeinterface_pipeline.ipynb
+++ b/notebooks/syntalos_spikeinterface_pipeline.ipynb
@@ -39,7 +39,8 @@
     "from nwb_conversion_tools.json_schema_utils import dict_deep_update\n",
     "from nwb_conversion_tools.conversion_tools import save_si_object\n",
     "\n",
-    "from mease_lab_to_nwb import SyntalosNWBConverter, SyntalosRecordingExtractor, SyntalosRecordingInterface"
+    "from mease_lab_to_nwb import SyntalosNWBConverter, SyntalosRecordingExtractor, SyntalosRecordingInterface\n",
+    "from mease_lab_to_nwb.syntalosnwbconverter import quick_write"
    ]
   },
   {
@@ -593,7 +594,7 @@
     "# Choose the sorting extractor from the notebook environment you would like to write to NWB\n",
     "chosen_sorting_extractor = sorting_outputs[('rec0', 'ironclust')]\n",
     "\n",
-    "se.SyntalosNWBConverter.quick_write(\n",
+    "quick_write(\n",
     "    intan_folder_path=syntalos_folder,\n",
     "    session_description=session_description,\n",
     "    save_path=nwbfile_path,\n",

--- a/notebooks/syntalos_spikeinterface_pipeline.ipynb
+++ b/notebooks/syntalos_spikeinterface_pipeline.ipynb
@@ -7,7 +7,8 @@
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
-    "%autoreload 2"
+    "%autoreload 2\n",
+    "%matplotlib notebook"
    ]
   },
   {
@@ -23,18 +24,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pprint import pprint\n",
+    "from datetime import datetime, timedelta\n",
+    "from isodate import duration_isoformat\n",
+    "\n",
     "import spikeextractors as se\n",
     "import spiketoolkit as st\n",
     "import spikesorters as ss\n",
     "import spikecomparison as sc\n",
     "import spikewidgets as sw\n",
-    "from pathlib import Path\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "from pprint import pprint\n",
-    "from pathlib import Path\n",
-    "from datetime import datetime\n",
-    "%matplotlib notebook"
+    "from nwb_conversion_tools.json_schema_utils import dict_deep_update\n",
+    "from nwb_conversion_tools.conversion_tools import save_si_object\n",
+    "\n",
+    "from mease_lab_to_nwb import SyntalosNWBConverter, SyntalosRecordingExtractor, SyntalosRecordingInterface"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1) Load Intan recordings, compute LFP, and inspect signals"
    ]
   },
   {
@@ -43,8 +55,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mease_lab_to_nwb import SyntalosRecordingExtractor\n",
-    "from nwb_conversion_tools.conversion_tools import save_si_object"
+    "syntalos_folder = Path('D:/Syntalos/Latest Syntalos Recording _20200730/intan-signals')\n",
+    "#syntalos_folder = Path('/Users/abuccino/Documents/Data/catalyst/heidelberg/syntalos/Latest_Syntalos_Recording_20200730/')\n",
+    "spikeinterface_folder = syntalos_folder / \"spikeinterface\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recording = SyntalosRecordingExtractor(syntalos_folder)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stub recording for fast testing; set to False for running processing pipeline on entire data"
    ]
   },
   {
@@ -58,60 +87,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "spikeinterface_folder = Path('spikeinterface')\n",
-    "spikeinterface_folder.mkdir(parents=True, exist_ok=True)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "## 1) Load Intan recordings, compute LFP, and inspect signals"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "syntalos_folder = Path('/Users/abuccino/Documents/Data/catalyst/heidelberg/syntalos/Latest_Syntalos_Recording_20200730/')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "recording = SyntalosRecordingExtractor(syntalos_folder)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
    "source": [
     "### Compute LFP"
    ]
@@ -140,11 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print(f\"Sampling frequency AP: {recording.get_sampling_frequency()}\")\n",
@@ -153,11 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Inspect signals"
    ]
@@ -174,11 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "w_ts_lf = sw.plot_timeseries(recording_lfp, trange=[10, 15])"
@@ -186,11 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## 2) Pre-processing"
    ]
@@ -217,8 +178,9 @@
     "    recording_processed = st.preprocessing.bandpass_filter(recording, freq_min=freq_min_hp, freq_max=freq_max_hp)\n",
     "else:\n",
     "    recording_processed = recording\n",
+    "\n",
     "if apply_cmr:\n",
-    "    recording_processed = st.preprocessing.common_reference(recording)\n",
+    "    recording_processed = st.preprocessing.common_reference(recording_processed)\n",
     "else:\n",
     "    recording_processed = recording"
    ]
@@ -230,8 +192,10 @@
    "outputs": [],
    "source": [
     "if stub_test:\n",
-    "    recoridng_processed = se.SubRecordingExtractor(recording_processed, \n",
-    "                                                   end_frame=int(30*recording_processed.get_sampling_frequency()))"
+    "    recording_processed = se.SubRecordingExtractor(recording_processed, \n",
+    "                                                   end_frame=int(nsec_stub*recording_processed.get_sampling_frequency()))\n",
+    "    recording_lfp = se.SubRecordingExtractor(recording_lfp,\n",
+    "                                           end_frame=int(nsec_stub*recording_lfp.get_sampling_frequency()))"
    ]
   },
   {
@@ -240,17 +204,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "num_frames = recording_processed.get_num_frames()"
+    "recording_processed.get_num_frames()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "w_ts_ap = sw.plot_timeseries(recording_processed)"
@@ -258,11 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## 3) Run spike sorters"
    ]
@@ -273,13 +229,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sorter_list = ['ironclust', 'klusta']"
+    "sorter_list = [\n",
+    "    \"ironclust\", # ironclust requires channel locations\n",
+    "    # \"waveclus\" # waveclust errors out, \"File type '' isn't supportedERROR: MATLAB error Exit Status: 0x00000001\"\n",
+    "]\n",
+    "ss.IronClustSorter.set_ironclust_path(\"D:/GitHub/ironclust\")\n",
+    "ss.WaveClusSorter.set_waveclus_path(\"D:/GitHub/wave_clus\")\n",
+    "\n",
+    "# For ironclust, channel locations must be set; defaulting to all zero\n",
+    "recording_processed.set_channel_locations(np.zeros((recording_processed.get_num_channels(),2)))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Inspect sorter-specific parameters and defaults\n",
@@ -287,7 +253,7 @@
     "    print(f\"{sorter} params description:\")\n",
     "    pprint(ss.get_params_description(sorter))\n",
     "    print(\"Default params:\")\n",
-    "    pprint(ss.get_default_params(sorter))    "
+    "    pprint(ss.get_default_params(sorter))"
    ]
   },
   {
@@ -297,60 +263,57 @@
    "outputs": [],
    "source": [
     "# user-specific parameters\n",
-    "sorter_params = dict(ironclust=dict(),\n",
-    "                     klusta=dict())"
+    "sorter_params = dict(\n",
+    "    ironclust=dict(),\n",
+    "    waveclus=dict()\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "scrolled": true
    },
    "outputs": [],
    "source": [
-    "sorting_outputs = ss.run_sorters(sorter_list=sorter_list, \n",
-    "                                 working_folder='syntalos_si_output',\n",
-    "                                 recording_dict_or_list=dict(rec0=recording_processed), \n",
-    "                                 sorter_params=sorter_params, mode='overwrite', verbose=True,\n",
-    "                                 run_sorter_kwargs={'raise_error': False})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "for result_name, sorting in sorting_outputs.items():\n",
-    "    rec_name, sorter = result_name\n",
-    "    print(f\"{sorter} found {len(sorting.get_unit_ids())} units\")"
+    "sorting_outputs = ss.run_sorters(\n",
+    "    sorter_list=sorter_list,\n",
+    "    working_folder=syntalos_folder / \"syntalos_si_output\",\n",
+    "    mode=\"keep\", # change to \"keep\" to avoid repeating the spike sorting\n",
+    "    recording_dict_or_list=dict(rec0=recording_processed),\n",
+    "    sorter_params=sorter_params,\n",
+    "    verbose=True\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
+   "source": [
+    "### (Optional) save individual sorting outputs for later use"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_si_object(\"ironclust\", sorting_outputs[('rec0', 'ironclust')], spikeinterface_folder,\n",
+    "               cache_raw=False, include_properties=True, include_features=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## 4) Post-processing: extract waveforms, templates, quality metrics, extracellular features"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Set postprocessing parameters"
    ]
@@ -358,11 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Post-processing params\n",
@@ -382,11 +341,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Set quality metric list"
    ]
@@ -394,11 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Quality metrics\n",
@@ -413,16 +364,12 @@
    "outputs": [],
    "source": [
     "# (optional) define subset of qc\n",
-    "qc_list = ['snr', 'isi_violation', 'firing_rate']"
+    "qc_list = [\"snr\", \"isi_violation\", \"firing_rate\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Set extracellular features"
    ]
@@ -430,11 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Extracellular features\n",
@@ -449,16 +392,12 @@
    "outputs": [],
    "source": [
     "# (optional) define subset of ec\n",
-    "ec_list = ['peak_to_valley', 'halfwidth']"
+    "ec_list = [\"peak_to_valley\", \"halfwidth\"]"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Postprocess all sorting outputs"
    ]
@@ -466,11 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "st.validation.compute_quality_metrics?"
@@ -483,10 +418,9 @@
    "outputs": [],
    "source": [
     "for result_name, sorting in sorting_outputs.items():\n",
-    "    print(f\"Postprocessing recording {rec_name} sorted with {sorter}\")\n",
     "    rec_name, sorter = result_name\n",
     "    tmp_folder = spikeinterface_folder / 'tmp' / sorter\n",
-    "    tmp_folder.mkdir(parents=True)\n",
+    "    tmp_folder.mkdir(parents=True, exist_ok=True)\n",
     "    \n",
     "    # set local tmp folder\n",
     "    sorting.set_tmp_folder(tmp_folder)\n",
@@ -506,153 +440,17 @@
     "    \n",
     "    # export to phy\n",
     "    phy_folder = spikeinterface_folder / 'phy' / sorter\n",
-    "    phy_folder.mkdir(parents=True, exist_ok=True)\n",
     "    st.postprocessing.export_to_phy(recording_processed, sorting, phy_folder)"
    ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "### Load Phy-curated data back to SI"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "!phy template-gui spikeinterface/phy/ironclust/params.py"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "phy_folder = 'spikeinterface/phy/ironclust/'\n",
-    "sorting_curated = se.PhySortingExtractor(phy_folder)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
-   "source": [
-    "## 5) Ensamble spike sorting\n"
+    "## 5) Ensemble spike sorting\n",
+    "\n",
+    "If len(sorter_list) > 1"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "if len(sorting_outputs) > 1:\n",
-    "    # retrieve sortings and sorter names\n",
-    "    sorting_list = []\n",
-    "    sorter_names_comp = []\n",
-    "    for result_name, sorting in sorting_outputs.items():\n",
-    "        rec_name, sorter = result_name\n",
-    "        sorting_list.append(sorting)\n",
-    "        sorter_names_comp.append(sorter)\n",
-    "        \n",
-    "    # run multisorting comparison\n",
-    "    mcmp = sc.compare_multiple_sorters(sorting_list=sorting_list, name_list=sorter_names_comp)\n",
-    "    \n",
-    "    # plot agreement results\n",
-    "    w_agr = sw.plot_multicomp_agreement(mcmp)\n",
-    "    \n",
-    "    # extract ensamble sorting\n",
-    "    sorting_ensamble = mcmp.get_agreement_sorting(minimum_agreement_count=2)\n",
-    "    \n",
-    "    print(f\"Ensamble sorting among {sorter_list} found: {len(sorting_ensamble.get_unit_ids())} units\")"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "markdown",
-   "source": [
-    "# 6) Automatic curation"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "# define curators and thresholds\n",
-    "isi_violation_threshold = 0.5\n",
-    "snr_threshold = 5\n",
-    "firing_rate_threshold = 0.1"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "sorting_auto_curated = []\n",
-    "sorter_names_curation = []\n",
-    "for result_name, sorting in sorting_outputs.items():\n",
-    "    rec_name, sorter = result_name\n",
-    "    sorter_names_curation.append(sorter)\n",
-    "    \n",
-    "    # firing rate threshold\n",
-    "    sorting_curated = st.curation.threshold_firing_rates(sorting, duration_in_frames=num_frames,\n",
-    "                                                         threshold=firing_rate_threshold, \n",
-    "                                                         threshold_sign='less')\n",
-    "    \n",
-    "    # isi violation threshold\n",
-    "    sorting_curated = st.curation.threshold_isi_violations(sorting, duration_in_frames=num_frames,\n",
-    "                                                           threshold=isi_violation_threshold, \n",
-    "                                                           threshold_sign='greater')\n",
-    "    \n",
-    "    # isi violation threshold\n",
-    "    sorting_curated = st.curation.threshold_snrs(sorting, recording=recording_processed,\n",
-    "                                                 threshold=snr_threshold, \n",
-    "                                                 threshold_sign='less')\n",
-    "    sorting_auto_curated.append(sorting_curated)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
   },
   {
    "cell_type": "code",
@@ -660,7 +458,61 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## 7) Save all outputs in spikeinterface folder"
+    "# retrieve sortings and sorter names\n",
+    "sorting_list = []\n",
+    "sorter_names_comp = []\n",
+    "for result_name, sorting in sorting_outputs.items():\n",
+    "    rec_name, sorter = result_name\n",
+    "    sorting_list.append(sorting)\n",
+    "    sorter_names_comp.append(sorter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# run multisorting comparison\n",
+    "mcmp = sc.compare_multiple_sorters(sorting_list=sorting_list, name_list=sorter_names)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot agreement results\n",
+    "w_agr = sw.plot_multicomp_agreement(mcmp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# extract ensemble sorting\n",
+    "sorting_ensemble = mcmp.get_agreement_sorting(minimum_agreement_count=2)\n",
+    "sorting_outputs.update(sorting_ensemble=sorting_ensemble)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### (Optional) save ensemble output for later use"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "save_si_object(\"sorting_ensemble\", sorting_ensemble, spikeinterface_folder,\n",
+    "               cache_raw=False, include_properties=True, include_features=False)"
    ]
   },
   {
@@ -694,6 +546,7 @@
     "    rec_name, sorter = result_name\n",
     "    sorter_names_curation.append(sorter)\n",
     "    \n",
+    "    num_frames = recording_processed.get_num_frames()\n",
     "    # firing rate threshold\n",
     "    sorting_curated = st.curation.threshold_firing_rates(sorting, duration_in_frames=num_frames,\n",
     "                                                         threshold=firing_rate_threshold, \n",
@@ -715,38 +568,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7) Save all outputs in spikeinterface folder"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cache_raw = False\n",
-    "cache_processed = False\n",
-    "cache_lfp = False\n",
-    "cache_sortings = True\n",
-    "cache_curated = True\n",
-    "cache_comparison = True"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cache_folder = spikeinterface_folder / 'cache'\n",
-    "cache_folder.mkdir(parents=True, exist_ok=True)"
+    "# 7) Quick save to NWB; writes only the spikes"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Dump recordings"
+    "## To complete the full conversion for other types of data, use the external script"
    ]
   },
   {
@@ -755,33 +584,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if cache_raw:\n",
-    "    recording_raw_cache = se.CacheRecordingExtractor(recording_ap_sync, \n",
-    "                                                     save_path=cache_folder / 'raw.dat')\n",
-    "else:\n",
-    "    recording_raw_cache = recording_ap_sync\n",
-    "recording_raw_cache.dump_to_pickle(cache_folder / 'raw.pkl')\n",
+    "# Name your NWBFile and decide where you want it saved\n",
+    "nwbfile_path = base_path / \"Syntalos.nwb\"\n",
     "\n",
-    "if cache_raw:\n",
-    "    recording_lfp_cache = se.CacheRecordingExtractor(recording_lf_sync, \n",
-    "                                                     save_path=cache_folder / 'lfp.dat')\n",
-    "else:\n",
-    "    recording_lfp_cache = recording_lf_sync\n",
-    "recording_lfp_cache.dump_to_pickle(cache_folder / 'lfp.pkl')\n",
+    "# Enter Session and Subject information here\n",
+    "session_description = \"Enter session description here.\"\n",
     "\n",
-    "if cache_processed:\n",
-    "    recording_processed_cache = se.CacheRecordingExtractor(recording_processed, \n",
-    "                                                           save_path=cache_folder / 'processed.dat')\n",
-    "else:\n",
-    "    recording_processed_cache = recording_processed\n",
-    "recording_processed_cache.dump_to_pickle(cache_folder / 'raw.pkl')"
+    "# Choose the sorting extractor from the notebook environment you would like to write to NWB\n",
+    "chosen_sorting_extractor = sorting_outputs[('rec0', 'ironclust')]\n",
+    "\n",
+    "se.SyntalosNWBConverter.quick_write(\n",
+    "    intan_folder_path=syntalos_folder,\n",
+    "    session_description=session_description,\n",
+    "    save_path=nwbfile_path,\n",
+    "    sorting=chosen_sorting_extractor,\n",
+    "    lfp=recording_lfp,\n",
+    "    timestamps=recording.get_timestamps(),\n",
+    "    overwrite=False\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Dump sortings"
+    "# 8) Full Save to NWB"
    ]
   },
   {
@@ -790,38 +617,49 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Sorter output\n",
-    "for result_name, sorting in sorting_outputs.items():\n",
-    "    rec_name, sorter = result_name\n",
-    "    if cache_sortings:\n",
-    "        sorting_cache = se.CacheSortingExtractor(sorting, cache_folder / f'sorting_{sorter}.npz')\n",
-    "    else:\n",
-    "        sorting_cache = sorting\n",
-    "    sorting_cache.dump_to_pickle(cache_folder / f'sorting_{sorter}.pkl', include_features=False)\n",
+    "# Specify the base path to the folder which contains the events, images, and intan folders\n",
+    "base_path = Path(\"D:/Syntalos/Latest Syntalos Recording _20200730\")\n",
     "\n",
-    "# Curated output\n",
-    "for (sorter, sorting_curated) in zip(sorter_names_curation, sorting_auto_curated):\n",
-    "    if cache_curated:\n",
-    "        sorting_auto_cache = se.CacheSortingExtractor(sorting_curated, cache_folder / f'sorting_{sorter}_auto.npz')\n",
-    "    else:\n",
-    "        sorting_auto_cache = sorting_curated\n",
-    "    sorting_auto_cache.dump_to_pickle(cache_folder / f'sorting_{sorter}_auto.pkl', include_features=False)\n",
-    "    \n",
-    "# Ensamble output\n",
-    "if cache_comparison:\n",
-    "    sorting_ensamble_cache = se.CacheSortingExtractor(sorting, cache_folder / f'sorting_ensamble.npz')\n",
-    "else:\n",
-    "    sorting_ensamble_cache = sorting_ensamble\n",
-    "sorting_ensamble_cache.dump_to_pickle(cache_folder / f'sorting_ensamble.pkl', include_features=False)"
+    "# Specify the file for the event table and the video folder\n",
+    "# If you do not have one of these, simply comment it out and the conversion will ignore it\n",
+    "event_file_path = base_path / \"events\" / \"table.csv\"\n",
+    "video_folder_path = base_path / \"videos\" / \"TIS Camera\"\n",
+    "\n",
+    "# Name your NWBFile and decide where you want it saved\n",
+    "nwbfile_path = base_path / \"Syntalos.nwb\"\n",
+    "\n",
+    "# Choose the sorting extractor from the notebook environment you would like to write to NWB\n",
+    "chosen_sorting_extractor = sorting_outputs[('rec0', 'ironclust')]\n",
+    "\n",
+    "# If you do not want to include the LFP data from the recording, comment out this variable\n",
+    "chosen_recording_lfp = recording_lfp\n",
+    "\n",
+    "# Enter Session and Subject information here\n",
+    "session_description = \"Enter session description here.\"\n",
+    "\n",
+    "# Uncomment any fields you want to include\n",
+    "subject_info = dict(\n",
+    "    subject_id=\"Enter optional subject id here\",\n",
+    "#    description=\"Enter optional subject description here\",\n",
+    "#    weight=\"Enter subject weight here\",\n",
+    "#    age=duration_isoformat(timedelta(days=0)),  # Enter the age of the subject in days\n",
+    "#    species=\"Mus musculus\",\n",
+    "#    genotype=\"Enter subject genotype here\",\n",
+    "#    sex=\"Enter subject sex here\"\n",
+    ")\n",
+    "\n",
+    "# Set some global conversion options here\n",
+    "# It's recommended to set stub_test to True on first attempt to ensure NWBFile output looks OK\n",
+    "conversion_stub_test = True\n",
+    "use_tsync_timestamps = True\n",
+    "overwrite = False  # If the NWBFile exists at the path, replace it"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Export to phy\n",
-    "\n",
-    "note to myself (add the possibility to save specific user defined properties)"
+    "## Run this cell to automatically perform conversion"
    ]
   },
   {
@@ -830,8 +668,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "st.postprocessing.export_to_phy"
+    "# Automatically performs conversion based on above filepaths and options\n",
+    "source_data = dict(\n",
+    "    SyntalosRecording=dict(folder_path=str(syntalos_folder.absolute()))\n",
+    ")\n",
+    "if \"event_file_path\" in locals():\n",
+    "    source_data.update(SyntalosEvent=dict(file_path=str(event_file_path.absolute())))\n",
+    "if \"video_folder_path\" in locals():\n",
+    "    source_data.update(SyntalosImage=dict(folder_path=str(video_folder_path.absolute())))\n",
+    "conversion_options = dict(\n",
+    "    SyntalosRecording=dict(stub_test=conversion_stub_test, use_timestamps=use_tsync_timestamps)\n",
+    ")\n",
+    "converter = SyntalosNWBConverter(source_data)\n",
+    "metadata = converter.get_metadata()\n",
+    "metadata = dict_deep_update(metadata, dict(Subject=subject_info))\n",
+    "metadata['NWBFile'].update(session_description=session_description)\n",
+    "run_args = dict(\n",
+    "    nwbfile_path=str(nwbfile_path.absolute()),\n",
+    "    metadata=metadata,\n",
+    "    save_to_file=True,\n",
+    "    conversion_options=conversion_options,\n",
+    "    sorting=chosen_sorting_extractor,\n",
+    "    timestamps=recording.get_timestamps(),\n",
+    "    overwrite=overwrite\n",
+    ")\n",
+    "if \"chosen_recording_lfp\" in locals():\n",
+    "    run_args.update(recording_lfp=chosen_recording_lfp)\n",
+    "converter.run_conversion(**run_args)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -850,16 +721,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "source": [],
-    "metadata": {
-     "collapsed": false
-    }
-   }
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@bendichter Easiest way to view these changes would just be the [direct notebook ](https://github.com/catalystneuro/mease-lab-to-nwb/blob/pipeline_conversion_improvements/notebooks/syntalos_spikeinterface_pipeline.ipynb)

Main changes are addition of two sections to end of pipeline

1. Quick save option; requires session description, some chosen sorting extractor, and then writes the minimal information from the notebook using a single operation. To complete the full conversion, user must use external script after the notebook file has completed creating the NWBFile

2. Full save option; essentially the code of the external script, but formatted in an even more slightly user friendly way. First cell involves all user-specific metainfo required for full conversion, second cell performs full run of both local environment objects as well as external files sources