### PR TITLE
get_channels_info

### DIFF
--- a/mease_lab_to_nwb/convert_ced/cednwbconverter.py
+++ b/mease_lab_to_nwb/convert_ced/cednwbconverter.py
@@ -1,6 +1,5 @@
 """Authors: Cody Baker and Ben Dichter."""
 from nwb_conversion_tools import NWBConverter, CEDRecordingInterface
-from spikeextractors import CEDRecordingExtractor
 
 
 class CEDNWBConverter(NWBConverter):
@@ -9,7 +8,7 @@ class CEDNWBConverter(NWBConverter):
     )
 
     def __init__(self, source_data):
-        channel_info = CEDRecordingExtractor.get_all_channels_info(source_data['CEDRecording']['file_path'])
+        channel_info = CEDRecordingInterface.get_all_channels_info(source_data['CEDRecording']['file_path'])
         rhd_channels = []
         for ch, info in channel_info.items():
             if "Rhd" in info["title"]:


### PR DESCRIPTION
get_all_channels_info will come directly from CEDRecordingInterface when https://github.com/catalystneuro/nwb-conversion-tools/pull/121 gets merged